### PR TITLE
Avoid unreadable "aside" on browsers without CSS nesting

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -612,14 +612,12 @@ aside {
   }
 }
 
-[data-theme='dark'] {
-  & aside {
-    border-color: var(--gray-6);
-    background-color: var(--gray-8);
-  }
-  & aside code:not(pre code) {
-    background-color: #f7708e33;
-  }
+[data-theme='dark'] aside {
+  border-color: var(--gray-6);
+  background-color: var(--gray-8);
+}
+[data-theme='dark'] aside code:not(pre code) {
+  background-color: #f7708e33;
 }
 
 /* ---------------------------------------------------------- */


### PR DESCRIPTION
This makes sure that degraded styling on browsers which don't support CSS nesting is still readable.  Without this patch, the white font is correctly picked up in dark mode, but the dark background for the "aside" element is not, leaving the content white-on-white.

Fixes #1