### PR TITLE
Another minor tweak for older browsers without CSS nesting

### DIFF
--- a/src/assets/css/prism-dracula.css
+++ b/src/assets/css/prism-dracula.css
@@ -5,6 +5,11 @@
  * Ported for PrismJS by Albert Vallverdu [@byverdu]
  */
 
+/* Critical fallback for browsers without CSS nesting support */
+[data-theme='dark'] [class*='language-'] {
+  color: #f8f8f2;
+}
+
 :where([data-theme='dark']) {
   & code[class*='language-'],
   & pre[class*='language-'] {


### PR DESCRIPTION
Similar to the last patch, this adds just enough fallback to make all code blocks readable to older browsers.